### PR TITLE
Updated action to use Node 24 and to refer to Node 24 in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This page lists the steps needed to set up a development environment and contrib
 
 1. Fork and clone this repo.
 
-2. Setup `nodejs` version `20`. We recommend using [asdf](https://asdf-vm.com/guide/getting-started.html).
+2. Setup `nodejs` version `24`. We recommend using [asdf](https://asdf-vm.com/guide/getting-started.html).
 
 3. Install dependencies.
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: true
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 
 branding:


### PR DESCRIPTION
#### Description

Updated runner to use the `node24` image and to refer to Node 24 in the `CONTRIBUTING.MD` documentation to address #23.
